### PR TITLE
Output to a new folder

### DIFF
--- a/Sources/ImageCramCLI/CommandLineError.swift
+++ b/Sources/ImageCramCLI/CommandLineError.swift
@@ -22,7 +22,7 @@ extension CommandLineError: CustomStringConvertible {
         case .apiKeyFileInvalid:
             return "API key file is missing, please try re-running, then updating ImageCram and then reporting the issue on GitHub if it persists."
         case let .failedToMoveFile(from, to):
-            return "Failed to remove file from \(from) to \(to)"
+            return "Failed to move file from \(from) to \(to)"
         case let .invalidInputFile(path):
             return "Cannot read input file at \(path)"
         case let .invalidOutput(path):

--- a/Sources/ImageCramCLI/FileMover.swift
+++ b/Sources/ImageCramCLI/FileMover.swift
@@ -23,9 +23,11 @@ struct FileMover {
         guard let outputPath = outputPath else {
             return inputFile.url
         }
-        guard let outputFolder = try? Folder(path: outputPath) else {
-            return URL(fileURLWithPath: outputPath)
+        let outputUrl = URL(fileURLWithPath: outputPath)
+        if outputUrl.pathExtension.isEmpty {
+            try FileManager.default.createDirectory(at: outputUrl, withIntermediateDirectories: true, attributes: [:])
+            return outputUrl.appendingPathComponent(inputFile.name)
         }
-        return URL(fileURLWithPath: outputFolder.path + "/" + inputFile.name)
+        return outputUrl
     }
 }

--- a/Sources/ImageCramTasks/Shell.swift
+++ b/Sources/ImageCramTasks/Shell.swift
@@ -9,11 +9,10 @@ struct ShellError: Error, CustomStringConvertible {
     }
 }
 
-func runShell(_ command: String, with arguments: [String] = [], continueOnError: Bool = false) throws {
+func runShell(_ command: String, continueOnError: Bool = false) throws {
     do {
         try shellOut(
             to: command,
-            arguments: arguments,
             outputHandle: .standardOutput,
             errorHandle: .standardError
         )


### PR DESCRIPTION
<!-- Thanks for your contribution to *Imagecram*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist
- [X] I've read the [guide for contributing](https://github.com/lordcodes/imagecram/blob/master/CONTRIBUTING.md).
- [X] I've checked there are no other [open pull requests](https://github.com/lordcodes/imagecram/pulls) for the same change.
- [X] I've made sure all the tests pass with `swift test`.
- [X] I've formatted all code changes with `swift run task format`.
- [X] I've ran all checks with `swift run task lint`.
- [X] I've updated documentation if needed.
- [X] I've added or updated tests for changes.

### Reason for change
<!-- If the pull request fixes an open issue, please include a link to the issue here. -->
<!-- Please explain why the change is required and the problem it solves. -->
Allow a new folder to be specified as the output location.

### Description
<!-- Please describe the changes you have made, providing as much detail as possible and including how the changes were tested. -->
If the output path doesn't have a file extension then use it as a folder. Create it if it doesn't exist yet.

Closes issue #2 
