### PR TITLE
Uninstall script deletes config

### DIFF
--- a/Sources/ImageCramTasks/main.swift
+++ b/Sources/ImageCramTasks/main.swift
@@ -62,6 +62,7 @@ extension Tasks {
 
         func run() throws {
             try runShell("rm -f /usr/local/bin/imagecram")
+            try runShell("rm -rf ~/Library/Preferences/ImageCram")
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for your contribution to *Imagecram*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist
- [X] I've read the [guide for contributing](https://github.com/lordcodes/imagecram/blob/master/CONTRIBUTING.md).
- [X] I've checked there are no other [open pull requests](https://github.com/lordcodes/imagecram/pulls) for the same change.
- [X] I've made sure all the tests pass with `swift test`.
- [X] I've formatted all code changes with `swift run task format`.
- [X] I've ran all checks with `swift run task lint`.
- [X] I've updated documentation if needed.
- [X] I've added or updated tests for changes.

### Reason for change
<!-- If the pull request fixes an open issue, please include a link to the issue here. -->
<!-- Please explain why the change is required and the problem it solves. -->
The uninstall task left the imagecram config directory containing the TinyPNG API key behind.

### Description
<!-- Please describe the changes you have made, providing as much detail as possible and including how the changes were tested. -->
Simply make the task delete the config directory.

Closes #3 